### PR TITLE
JWT-Knox: Include Authorization header prefix

### DIFF
--- a/xea-core/jwt_knox/auth.py
+++ b/xea-core/jwt_knox/auth.py
@@ -1,21 +1,20 @@
 import jwt
-
 from django.contrib.auth import get_user_model
+from django.utils import timezone
 from django.utils.encoding import smart_text
 from django.utils.translation import ugettext as _
-
-from rest_framework import exceptions
-from rest_framework.authentication import BaseAuthentication, get_authorization_header
-
 from knox.crypto import hash_token
 from knox.models import AuthToken
+from rest_framework import exceptions
+from rest_framework.authentication import (BaseAuthentication,
+                                           get_authorization_header)
 
 from jwt_knox.settings import api_settings
-
 
 jwt_decode_handler = api_settings.JWT_DECODE_HANDLER
 jwt_get_username_from_payload = api_settings.JWT_PAYLOAD_GET_USERNAME_HANDLER
 jwt_get_knox_token_from_payload = api_settings.JWT_PAYLOAD_GET_TOKEN_HANDLER
+
 
 class BaseJWTTAuthentication(BaseAuthentication):
     """
@@ -59,7 +58,6 @@ class BaseJWTTAuthentication(BaseAuthentication):
             raise exceptions.AuthenticationFailed(msg)
 
         return (user, self.ensure_valid_auth_token(user, token))
-
 
     def ensure_valid_auth_token(self, user, token):
         for auth_token in AuthToken.objects.filter(user=user):
@@ -114,7 +112,6 @@ class JSONWebTokenKnoxAuthentication(BaseJWTTAuthentication):
 
         return payload
 
-
     def authenticate_header(self, request):
         """
         Return a string to be used as the value of WWW-Authenticate
@@ -122,5 +119,5 @@ class JSONWebTokenKnoxAuthentication(BaseJWTTAuthentication):
         authentication scheme should return 403 Permission Denied respones.
         """
 
-        return '{0} realm="{1}"'.format(api_settings.JWT_AUTH_HEADER_PREFIX, self.www_authenticate_realm)
-
+        return '{0} realm="{1}"'.format(api_settings.JWT_AUTH_HEADER_PREFIX,
+                                        self.www_authenticate_realm)

--- a/xea-core/jwt_knox/tests.py
+++ b/xea-core/jwt_knox/tests.py
@@ -1,8 +1,7 @@
 from django.core.urlresolvers import reverse
-from rest_framework.test import APIClient, APITestCase
+from rest_framework.test import APITestCase
 from django.contrib.auth.models import User
 from rest_framework import status
-from .settings import api_settings
 
 
 class APIAuthTest(APITestCase):
@@ -38,12 +37,7 @@ class APIAuthTest(APITestCase):
             self.client.credentials(HTTP_AUTHORIZATION=None)
             return self
 
-        auth_header = "{prefix} {token}".format(
-            prefix=api_settings.JWT_AUTH_HEADER_PREFIX,
-            token=token
-        )
-
-        self.client.credentials(HTTP_AUTHORIZATION=auth_header)
+        self.client.credentials(HTTP_AUTHORIZATION=token)
 
         return self
 
@@ -79,17 +73,6 @@ class APIAuthTest(APITestCase):
             self.assertEqual(response.status_code, status.HTTP_200_OK)
             response_list.append(response)
         return response_list
-
-    @staticmethod
-    def build_auth_header(token):
-        """
-        This method allows to build the authentication header that a client could use for his future requests.
-        :param token: the token we want to use to authenticate the client
-        :return:
-        """
-        header = "{prefix} {token}".format(prefix=api_settings.JWT_AUTH_HEADER_PREFIX,
-                                           token=token)
-        return header
 
     def test_get_token(self):
         """

--- a/xea-core/jwt_knox/utils.py
+++ b/xea-core/jwt_knox/utils.py
@@ -1,6 +1,5 @@
 import jwt
 import uuid
-import warnings
 from calendar import timegm
 from datetime import datetime
 
@@ -18,6 +17,7 @@ def get_username_field():
         username_field = 'username'
 
     return username_field
+
 
 def get_username(user):
     try:
@@ -37,6 +37,7 @@ def create_auth_token(user, expires):
 
 def jwt_get_token_from_payload_handler(payload):
     return payload.get('jti')
+
 
 def jwt_get_username_from_payload_handler(payload):
     return payload.get('username')
@@ -70,17 +71,12 @@ def jwt_payload_handler(user, token, expires):
 
 
 def jwt_encode_handler(payload):
-    return jwt.encode(
-        payload,
-        api_settings.JWT_SECRET_KEY,
-        api_settings.JWT_ALGORITHM
-    ).decode('utf-8')
+    return jwt.encode(payload, api_settings.JWT_SECRET_KEY,
+                      api_settings.JWT_ALGORITHM).decode('utf-8')
 
 
 def jwt_decode_handler(token):
-    options = {
-        'verify_exp': True,
-    }
+    options = {'verify_exp': True, }
 
     return jwt.decode(
         token,
@@ -90,12 +86,13 @@ def jwt_decode_handler(token):
         leeway=api_settings.JWT_LEEWAY,
         audience=api_settings.JWT_AUDIENCE,
         issuer=api_settings.JWT_ISSUER,
-        algorithms=[api_settings.JWT_ALGORITHM],
-    )
+        algorithms=[api_settings.JWT_ALGORITHM], )
+
+
+def jwt_join_header_and_token(token):
+    return "{0} {1}".format(api_settings.JWT_AUTH_HEADER_PREFIX,
+                            token, )
+
 
 def jwt_response_payload_handler(token, user=None, request=None):
-    return {
-        'token': token,
-    }
-
-
+    return {'token': jwt_join_header_and_token(token), }

--- a/xea-core/jwt_knox/views.py
+++ b/xea-core/jwt_knox/views.py
@@ -1,10 +1,7 @@
 from rest_framework import status
-from rest_framework.permissions import IsAuthenticated, IsAdminUser
+from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.views import APIView
-
-from knox.models import AuthToken
-from knox.settings import knox_settings
 
 from jwt_knox.auth import JSONWebTokenKnoxAuthentication
 from jwt_knox.settings import api_settings


### PR DESCRIPTION
Include the "Bearer" header prefix in the token response at get_token,
so that it needn't be documented in the API Docs, but is instead
provided by the API endpoint proper.
