### PR TITLE
Add LGTM configuration for LGTM.co

### DIFF
--- a/.lgtm
+++ b/.lgtm
@@ -1,0 +1,2 @@
+approvals = 1
+pattern  = "(?i):shipit:|:\\+1:|LGTM"

--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1,0 +1,11 @@
+# This file keeps the current MAINTAINERS of this repo.
+
+# This is needed for Lgtm.co/lgtm plugin in our repository, but also
+# for any other concerns regarding maintenance of this project.
+# The following are usernames on GitHub
+
+ssaavedra
+castrinho8
+braisarias
+asincrono
+therealtod


### PR DESCRIPTION
Add LGTM configuration so that we can use protected branches in
GitHub as we were doing so in GitLab.
