### PR TITLE
Update eslint dependency

### DIFF
--- a/xea-web/package.json
+++ b/xea-web/package.json
@@ -55,7 +55,7 @@
     "cross-env": "1.0.8",
     "css-loader": "0.23.1",
     "enzyme": "2.4.1",
-    "eslint": "3.2.2",
+    "eslint": "3.3.0",
     "eslint-config-airbnb": "10.0.0",
     "eslint-config-standard": "5.3.5",
     "eslint-config-standard-jsx": "2.0.0",


### PR DESCRIPTION
Update eslint dependency caused by a compatibility error with eslint-config-airbnb
