### PR TITLE
Add CORS and enable for all domains

### DIFF
--- a/xea-core/requirements.txt
+++ b/xea-core/requirements.txt
@@ -1,6 +1,7 @@
 cffi==1.7.0
 cryptography==1.4
 Django==1.9.8
+django-cors-headers>=1.1.0,<2.0.0
 django-debug-toolbar==1.5
 django-filter==0.13.0
 django-rest-knox==2.2.0

--- a/xea-core/xea_core/settings.py
+++ b/xea-core/xea_core/settings.py
@@ -37,6 +37,7 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
+    'corsheaders',
     'debug_toolbar',
     'rest_framework',
     'knox',
@@ -47,6 +48,9 @@ INSTALLED_APPS = [
 MIDDLEWARE_CLASSES = [
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
+    # Django CORS must be before CommonMiddlware if using USE_ETAGS=True
+    'corsheaders.middleware.CorsMiddleware',
+
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
@@ -111,6 +115,11 @@ REST_FRAMEWORK = {
         'rest_framework.authentication.SessionAuthentication',
     )
 }
+
+
+# CORS Configuration
+
+CORS_ORIGIN_ALLOW_ALL = True
 
 
 # Internationalization


### PR DESCRIPTION
Adds CORS support for Django via django-cors-headers.

Enables CORS for incoming requests from all hosts.
